### PR TITLE
Enable DB connections from running docker container

### DIFF
--- a/.docker/deploy/scripts/init.sh
+++ b/.docker/deploy/scripts/init.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
+set -eou pipefail
+
 # Entry script for base container image
+if [ -n "${PROGRESS_CFG_BASE64:-}" ]; then
+  base64 --decode <<< "$PROGRESS_CFG_BASE64" > "$DLC/progress.cfg"
+fi
 
-base64 --decode <<< "$PROGRESS_CFG_BASE64" > "$DLC/progress.cfg"
-
-chown -R --reference=/psc/dlc pscadmin /psc/wrk
+# chown -R --reference=/psc/dlc pscadmin /psc/wrk
+chmod -R 777 /psc/dlc/bin
+chmod u+s /psc/dlc/bin/_mprosrv
 
 SCRIPTPATH=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 

--- a/.docker/deploy/scripts/start-db-server.sh
+++ b/.docker/deploy/scripts/start-db-server.sh
@@ -63,6 +63,9 @@ then
   { echo "ERROR: Failed to start database server!. Exiting. \($status\)"; cat ${DB_DIR}/${DB_NAME} exit $status; }
 fi
 
+# test the DB connection from within the container
+_progres -b -p /home/pscadmin/src/main/db_test.p
+
 shutdown_gracefully() {
   echo "Shutdown the database '${DB_NAME}'"
   

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ progress*.cfg
 ~*
 *.e
 *.hex
+*.lg
 *.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,8 @@ services:
       - DB_MAXPORT=2699
     # network_mode: host
     ports:
-      - '127.0.0.1:2500:3500'
-      - '127.0.0.1:2600-2699:3600-3699'
+      - '127.0.0.1:2500:2500'
+      - '127.0.0.1:2600-2699:2600-2699'
     volumes:
       - ${DLC}/progress.cfg:/psc/dlc/progress.cfg:ro
     secrets:

--- a/src/main/db_test.p
+++ b/src/main/db_test.p
@@ -1,6 +1,10 @@
 message 100 num-dbs.
 if num-dbs = 0 then
-  connect -db sp2k -H oedb -S 3500 no-error.
+do:
+  connect -db sp2k -H localhost -S 2500 no-error.
+  // connect -db sp2k -H 172.17.55.11 -S 2500 no-error.
+  // connect -db sp2k -H 172.17.48.1 -S 2500 no-error.
+end.
 message 101 num-dbs error-status:error error-status:num-messages.
 if error-status:error then
   message 102 error-status:get-message(1).


### PR DESCRIPTION
This PR confirms DB connections from a running docker container can be used for development activities.  This serves as an example of how teams can leverage docker to ensure all developers are using the same schema/data for consistency.

This helps to reduce the "works on my machine" problems often encountered when working as a team.

## TODO

This currently isn't working with the community license.  Need to figure out if that's a limitation of the license or not.